### PR TITLE
feat: allow configuring default MQTT topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,18 @@ g++ -std=c++17 -DPAHO_MQTT src/*.cpp tests/test_driver.cpp \
     -lpaho-mqttpp3 -lpaho-mqtt3as -o example
 
 ```
+
+## Python usage
+
+The Python package exposes the same controller.  Default MQTT topic paths can
+be changed at runtime:
+
+```python
+from roro_mqtt import MQTTRoofController, configure_topics
+
+configure_topics(open="observatory/roof/open", close="observatory/roof/close")
+controller = MQTTRoofController(host="mqtt.example.net")
+```
+
+Call ``configure_topics()`` without arguments to reset to the built-in
+defaults.

--- a/roro_mqtt/__init__.py
+++ b/roro_mqtt/__init__.py
@@ -1,5 +1,5 @@
 """MQTT-based roll-on roll-off roof controller."""
 
-from .driver import MQTTRoofController
+from .driver import MQTTRoofController, configure_topics
 
-__all__ = ["MQTTRoofController"]
+__all__ = ["MQTTRoofController", "configure_topics"]


### PR DESCRIPTION
## Summary
- add module-level `configure_topics` to adjust MQTT paths
- use configured topics as defaults for new controllers
- document Python usage and add tests for dynamic topic configuration

## Testing
- `pytest -q`
- `g++ -std=c++17 src/mqtt_roof_controller.cpp tests/test_driver.cpp -Iinclude -o test_driver && ./test_driver`


------
https://chatgpt.com/codex/tasks/task_e_68a445b3a2f0832e85e731a9228a12a6