### PR TITLE
Fetch GoogleTest with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.14)
 project(indi_mqtt_universalror)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -13,9 +13,17 @@ target_link_libraries(indi-mqtt-universalror indidriver indiclient paho-mqttpp3 
 add_executable(mqtt_publish tools/mqtt_publish.cpp)
 target_link_libraries(mqtt_publish paho-mqttpp3 paho-mqtt3as pthread)
 
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG v1.14.0
+)
+FetchContent_MakeAvailable(googletest)
+
 add_executable(state_machine_test tests/state_machine_test.cpp src/state_machine.cpp)
 
-target_link_libraries(state_machine_test gtest gtest_main pthread)
+target_link_libraries(state_machine_test gtest_main pthread)
 
 enable_testing()
 add_test(NAME state_machine_test COMMAND state_machine_test)


### PR DESCRIPTION
## Summary
- use CMake FetchContent to download GoogleTest during configuration
- link state_machine_test against gtest_main

## Testing
- `cmake --build build --target state_machine_test -j`
- `cd build && ctest && cd ..`


------
https://chatgpt.com/codex/tasks/task_e_68b165260d7c832ea143f06e6e97558b