### PR TITLE
Add build and install script for MQTT Universal ROR driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ project(indi_mqtt_universalror)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+include(GNUInstallDirs)
+
 include_directories(/usr/include/libindi include)
 
 add_executable(indi-mqtt-universalror src/mqtt_universalror.cpp src/state_machine.cpp)
@@ -27,3 +29,7 @@ target_link_libraries(state_machine_test gtest_main pthread)
 
 enable_testing()
 add_test(NAME state_machine_test COMMAND state_machine_test)
+
+install(TARGETS indi-mqtt-universalror DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(FILES mqtt_universalror.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/indi)
+install(FILES indi-mqtt-universalror.rules DESTINATION ${CMAKE_INSTALL_LIBDIR}/udev/rules.d)

--- a/build_and_install.sh
+++ b/build_and_install.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BUILD_DIR="build"
+
+cmake -B "$BUILD_DIR" -S . "$@"
+cmake --build "$BUILD_DIR" --parallel
+
+pushd "$BUILD_DIR" >/dev/null
+ctest --output-on-failure
+popd >/dev/null
+
+if [ "$(id -u)" -ne 0 ]; then
+  sudo cmake --install "$BUILD_DIR"
+else
+  cmake --install "$BUILD_DIR"
+fi
+
+echo "Installation complete. Restart Ekos/KStars to load the MQTT Universal ROR driver."


### PR DESCRIPTION
## Summary
- add `build_and_install.sh` script to compile, test and install the driver
- update CMake to install driver, XML descriptor and udev rule so Ekos can detect the driver

## Testing
- `./build_and_install.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b187d1ffb0832ebfae86705648cb73