### PR TITLE
Add configuration support for MQTT topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ and delegates all physical I/O to MQTT topics.  Limit switches and safety
 events are mirrored to standard INDI dome properties.  A simple state machine
 guards valid transitions and is unit tested with GoogleTest.
 
+### Configuration
+
+The driver adds an `MQTT_TOPICS` text property in the *Configuration* tab.
+Topics for open/close/stop commands and limit switches can be edited and are
+stored using the standard INDI configuration mechanism.
+
 ### Build
 
 ```

--- a/include/mqtt_universalror.h
+++ b/include/mqtt_universalror.h
@@ -24,17 +24,24 @@ public:
 
     void mqtt_message_arrived(std::string topic, std::string payload);
 
+    virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) override;
+    virtual bool saveConfigItems(FILE *fp) override;
+
 private:
     void publish_command(const std::string &topic);
     void setup_mqtt();
 
     mqtt::async_client client_;
     RoofStateMachine fsm_;
-    std::string topic_open_; 
+
+    std::string topic_open_;
     std::string topic_close_;
     std::string topic_stop_;
     std::string topic_limit_open_;
     std::string topic_limit_closed_;
+
+    IText mqtt_topics_t_[5];
+    ITextVectorProperty mqtt_topics_tp_;
 };
 
 } // namespace roro

--- a/src/mqtt_universalror.cpp
+++ b/src/mqtt_universalror.cpp
@@ -1,5 +1,6 @@
 #include "mqtt_universalror.h"
 #include <chrono>
+#include <cstring>
 #include <thread>
 
 using namespace std::chrono_literals;
@@ -19,11 +20,19 @@ bool MQTTUniversalROR::initProperties() {
     INDI::Dome::initProperties();
     addDebugControl();
     // Topics defaults
-    topic_open_ = "observatory/roof/cmd/open";
-    topic_close_ = "observatory/roof/cmd/close";
-    topic_stop_ = "observatory/roof/cmd/stop";
-    topic_limit_open_ = "observatory/roof/limit/open";
-    topic_limit_closed_ = "observatory/roof/limit/closed";
+    IUFillText(&mqtt_topics_t_[0], "OPEN", "Open", "observatory/roof/cmd/open");
+    IUFillText(&mqtt_topics_t_[1], "CLOSE", "Close", "observatory/roof/cmd/close");
+    IUFillText(&mqtt_topics_t_[2], "STOP", "Stop", "observatory/roof/cmd/stop");
+    IUFillText(&mqtt_topics_t_[3], "LIMIT_OPEN", "Limit Open", "observatory/roof/limit/open");
+    IUFillText(&mqtt_topics_t_[4], "LIMIT_CLOSED", "Limit Closed", "observatory/roof/limit/closed");
+    IUFillTextVector(&mqtt_topics_tp_, mqtt_topics_t_, 5, getDeviceName(), "MQTT_TOPICS", "MQTT Topics", "Configuration", IP_RW, 60, IPS_IDLE);
+    loadConfig(true);
+    topic_open_ = mqtt_topics_t_[0].text;
+    topic_close_ = mqtt_topics_t_[1].text;
+    topic_stop_ = mqtt_topics_t_[2].text;
+    topic_limit_open_ = mqtt_topics_t_[3].text;
+    topic_limit_closed_ = mqtt_topics_t_[4].text;
+    defineText(&mqtt_topics_tp_);
     return true;
 }
 
@@ -59,6 +68,29 @@ IPState MQTTUniversalROR::UnPark() {
 bool MQTTUniversalROR::Abort() {
     fsm_.command_stop();
     publish_command(topic_stop_);
+    return true;
+}
+
+bool MQTTUniversalROR::ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) {
+    if (strcmp(dev, getDeviceName()) == 0) {
+        if (!strcmp(name, mqtt_topics_tp_.name)) {
+            IUUpdateText(&mqtt_topics_tp_, texts, names, n);
+            topic_open_ = mqtt_topics_t_[0].text;
+            topic_close_ = mqtt_topics_t_[1].text;
+            topic_stop_ = mqtt_topics_t_[2].text;
+            topic_limit_open_ = mqtt_topics_t_[3].text;
+            topic_limit_closed_ = mqtt_topics_t_[4].text;
+            mqtt_topics_tp_.s = IPS_OK;
+            IDSetText(&mqtt_topics_tp_, nullptr);
+            return true;
+        }
+    }
+    return INDI::Dome::ISNewText(dev, name, texts, names, n);
+}
+
+bool MQTTUniversalROR::saveConfigItems(FILE *fp) {
+    INDI::Dome::saveConfigItems(fp);
+    IUSaveConfigText(fp, &mqtt_topics_tp_);
     return true;
 }
 


### PR DESCRIPTION
## Summary
- allow editing MQTT command and limit topics via new `MQTT_TOPICS` property
- persist topic settings using standard INDI configuration

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68b18cb40c70832e9f8624f4857dcad1