### PR TITLE
Ensure clean installs and define driver capabilities

### DIFF
--- a/build_and_install.sh
+++ b/build_and_install.sh
@@ -2,18 +2,27 @@
 set -euo pipefail
 
 BUILD_DIR="build"
+INSTALL_PREFIX="/usr"
 
-cmake -B "$BUILD_DIR" -S . "$@"
+if [ "$(id -u)" -ne 0 ]; then
+  SUDO="sudo"
+else
+  SUDO=""
+fi
+
+cmake -B "$BUILD_DIR" -S . -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" "$@"
 cmake --build "$BUILD_DIR" --parallel
 
 pushd "$BUILD_DIR" >/dev/null
 ctest --output-on-failure
 popd >/dev/null
 
-if [ "$(id -u)" -ne 0 ]; then
-  sudo cmake --install "$BUILD_DIR"
-else
-  cmake --install "$BUILD_DIR"
-fi
+for prefix in /usr /usr/local; do
+  $SUDO rm -f "$prefix/bin/indi-mqtt-universalror" \
+    "$prefix/share/indi/mqtt_universalror.xml" \
+    "$prefix/lib/udev/rules.d/indi-mqtt-universalror.rules" || true
+done
+
+$SUDO cmake --install "$BUILD_DIR"
 
 echo "Installation complete. Restart Ekos/KStars to load the MQTT Universal ROR driver."

--- a/src/mqtt_universalror.cpp
+++ b/src/mqtt_universalror.cpp
@@ -12,7 +12,11 @@ static const char *PROP_CLOSE = "DOME_CLOSE";
 static const char *PROP_STOP = "DOME_STOP";
 
 MQTTUniversalROR::MQTTUniversalROR()
-    : client_("tcp://localhost:1883", "indi-mqtt-universalror") {}
+    : client_("tcp://localhost:1883", "indi-mqtt-universalror")
+{
+    setVersion(1, 0);
+    SetDomeCapability(DOME_CAN_ABORT | DOME_CAN_PARK);
+}
 
 const char *MQTTUniversalROR::getDefaultName() { return "MQTT Universal ROR"; }
 


### PR DESCRIPTION
## Summary
- remove previous installs before reinstalling and install to /usr by default
- set driver version and dome capabilities so the driver registers correctly

## Testing
- `./build_and_install.sh` *(fails: indidome.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b190bde06c832eb6f25058db061e7a