### PR TITLE
Ensure KStars recognizes MQTT Universal ROR driver

### DIFF
--- a/mqtt_universalror.xml
+++ b/mqtt_universalror.xml
@@ -1,6 +1,8 @@
-<indi> 
-  <device label="MQTT Universal ROR" name="MQTT Universal ROR"> 
-    <driver name="indi-mqtt-universalror" />
-    <version>1.0</version>
-  </device>
+<indi>
+  <devGroup group="Domes">
+    <device label="MQTT Universal ROR" manufacturer="RORO-MQTT">
+      <driver name="MQTT Universal ROR">indi-mqtt-universalror</driver>
+      <version>1.0</version>
+    </device>
+  </devGroup>
 </indi>


### PR DESCRIPTION
## Summary
- Categorize driver under Domes in the INDI XML so KStars can display it

## Testing
- `./build_and_install.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b19d42cba0832e86c068c89e98e8a1