### PR TITLE
Advertise dome interface

### DIFF
--- a/src/mqtt_universalror.cpp
+++ b/src/mqtt_universalror.cpp
@@ -15,6 +15,9 @@ MQTTUniversalROR::MQTTUniversalROR()
     : client_("tcp://localhost:1883", "indi-mqtt-universalror")
 {
     setVersion(1, 0);
+    // Advertise this driver as a dome so that KStars lists it under the
+    // Dome devices and enables the appropriate controls in the GUI.
+    setDriverInterface(DOME_INTERFACE);
     SetDomeCapability(DOME_CAN_ABORT | DOME_CAN_PARK);
 }
 


### PR DESCRIPTION
## Summary
- ensure MQTT ROR driver registers as a dome interface so KStars lists it in the Dome group and exposes GUI controls

## Testing
- `./build_and_install.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b1a1b90248832e825e9fbd83d76900