### PR TITLE
feat: snoop telescope state

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,10 @@ target_link_libraries(state_machine_test gtest_main pthread)
 enable_testing()
 add_test(NAME state_machine_test COMMAND state_machine_test)
 
+add_executable(test_driver tests/test_driver.cpp src/mqtt_roof_controller.cpp)
+target_link_libraries(test_driver pthread)
+add_test(NAME test_driver COMMAND test_driver)
+
 install(TARGETS indi-mqtt-universalror DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(FILES mqtt_universalror.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/indi)
 install(FILES indi-mqtt-universalror.rules DESTINATION ${CMAKE_INSTALL_LIBDIR}/udev/rules.d)

--- a/include/mqtt_roof_controller.h
+++ b/include/mqtt_roof_controller.h
@@ -14,7 +14,8 @@ public:
                        const std::string& topic_open_limit = "",
                        const std::string& topic_close_limit = "",
                        const std::string& topic_percent = "",
-                       const std::string& topic_power = "");
+                       const std::string& topic_power = "",
+                       const std::string& topic_telescope = "");
 
     void connect();
     void disconnect();
@@ -25,6 +26,7 @@ public:
 
     bool is_open() const { return open_state_; }
     bool is_closed() const { return close_state_; }
+    bool is_telescope_parked() const { return telescope_parked_; }
 
 private:
     std::shared_ptr<IMqttClient> client_;
@@ -34,9 +36,11 @@ private:
     std::string topic_close_limit_;
     std::string topic_percent_;
     std::string topic_power_;
+    std::string topic_telescope_;
 
     bool open_state_ = false;
     bool close_state_ = false;
+    bool telescope_parked_ = false;
 };
 
 #endif // MQTT_ROOF_CONTROLLER_H

--- a/src/mqtt_roof_controller.cpp
+++ b/src/mqtt_roof_controller.cpp
@@ -8,14 +8,16 @@ MQTTRoofController::MQTTRoofController(std::shared_ptr<IMqttClient> client,
                                        const std::string& topic_open_limit,
                                        const std::string& topic_close_limit,
                                        const std::string& topic_percent,
-                                       const std::string& topic_power)
+                                       const std::string& topic_power,
+                                       const std::string& topic_telescope)
     : client_(std::move(client)),
       topic_open_(topic_open),
       topic_close_(topic_close),
       topic_open_limit_(topic_open_limit),
       topic_close_limit_(topic_close_limit),
       topic_percent_(topic_percent),
-      topic_power_(topic_power) {}
+      topic_power_(topic_power),
+      topic_telescope_(topic_telescope) {}
 
 void MQTTRoofController::connect() {
     client_->connect();
@@ -27,6 +29,11 @@ void MQTTRoofController::connect() {
     if (!topic_close_limit_.empty()) {
         client_->subscribe(topic_close_limit_, [this](const std::string& payload) {
             close_state_ = (payload != "0");
+        });
+    }
+    if (!topic_telescope_.empty()) {
+        client_->subscribe(topic_telescope_, [this](const std::string& payload) {
+            telescope_parked_ = (payload != "0");
         });
     }
 }

--- a/tests/test_driver.cpp
+++ b/tests/test_driver.cpp
@@ -35,7 +35,8 @@ int main() {
                                  "roof/open_limit",
                                  "roof/close_limit",
                                  "roof/percent",
-                                 "roof/power");
+                                 "roof/power",
+                                 "telescope/parked");
     controller.connect();
 
     controller.set_power(true);
@@ -52,8 +53,10 @@ int main() {
     // Simulate limit switch callbacks
     client->emit("roof/open_limit", "1");
     client->emit("roof/close_limit", "1");
+    client->emit("telescope/parked", "1");
     assert(controller.is_open());
     assert(controller.is_closed());
+    assert(controller.is_telescope_parked());
 
     std::cout << "All tests passed\n";
     return 0;


### PR DESCRIPTION
## Summary
- allow MQTTRoofController to subscribe to a telescope parked topic
- test telescope snooping in driver example
- compile test_driver as part of CTest

## Testing
- `ctest`


------
https://chatgpt.com/codex/tasks/task_e_68b1aa3d7b84832ebd17f988720cf682