### PR TITLE
Block commands in error state

### DIFF
--- a/src/state_machine.cpp
+++ b/src/state_machine.cpp
@@ -6,7 +6,8 @@ RoofStateMachine::RoofStateMachine() : state_(RoofState::UNKNOWN) {}
 
 bool RoofStateMachine::command_open() {
     std::lock_guard<std::mutex> lock(mutex_);
-    if (state_ == RoofState::OPEN || state_ == RoofState::OPENING)
+    if (state_ == RoofState::OPEN || state_ == RoofState::OPENING ||
+        state_ == RoofState::ERROR)
         return false;
     state_ = RoofState::OPENING;
     return true;
@@ -14,7 +15,8 @@ bool RoofStateMachine::command_open() {
 
 bool RoofStateMachine::command_close() {
     std::lock_guard<std::mutex> lock(mutex_);
-    if (state_ == RoofState::CLOSED || state_ == RoofState::CLOSING)
+    if (state_ == RoofState::CLOSED || state_ == RoofState::CLOSING ||
+        state_ == RoofState::ERROR)
         return false;
     state_ = RoofState::CLOSING;
     return true;

--- a/tests/state_machine_test.cpp
+++ b/tests/state_machine_test.cpp
@@ -20,6 +20,14 @@ TEST(StateMachine, Stop) {
     EXPECT_EQ(fsm.state(), RoofState::ERROR);
 }
 
+TEST(StateMachine, CommandsIgnoredInErrorState) {
+    RoofStateMachine fsm;
+    EXPECT_TRUE(fsm.command_open());
+    fsm.command_stop();
+    EXPECT_FALSE(fsm.command_open());
+    EXPECT_FALSE(fsm.command_close());
+}
+
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
## Summary
- prevent open/close commands from executing when state machine is in ERROR
- test that commands are ignored after entering the error state

## Testing
- `g++ -std=c++17 -I../include ../src/state_machine.cpp ../tests/state_machine_test.cpp -lgtest -lpthread -o state_machine_test && ./state_machine_test`
- `make -j4` *(fails: fatal error: indidome.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ab9f3d3c832e9d20893271637c33