### PR TITLE
Add driver advertisement XML template

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,5 +35,9 @@ target_link_libraries(test_driver pthread)
 add_test(NAME test_driver COMMAND test_driver)
 
 install(TARGETS indi-mqtt-universalror DESTINATION ${CMAKE_INSTALL_BINDIR})
-install(FILES mqtt_universalror.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/indi)
+configure_file(indi-mqtt-universalror.xml.cmake
+               ${CMAKE_CURRENT_BINARY_DIR}/indi-mqtt-universalror.xml
+               @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/indi-mqtt-universalror.xml
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/indi)
 install(FILES indi-mqtt-universalror.rules DESTINATION ${CMAKE_INSTALL_LIBDIR}/udev/rules.d)

--- a/build_and_install.sh
+++ b/build_and_install.sh
@@ -19,7 +19,7 @@ popd >/dev/null
 
 for prefix in /usr /usr/local; do
   $SUDO rm -f "$prefix/bin/indi-mqtt-universalror" \
-    "$prefix/share/indi/mqtt_universalror.xml" \
+    "$prefix/share/indi/indi-mqtt-universalror.xml" \
     "$prefix/lib/udev/rules.d/indi-mqtt-universalror.rules" || true
 done
 

--- a/indi-mqtt-universalror.xml.cmake
+++ b/indi-mqtt-universalror.xml.cmake
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<driversList>
+   <devGroup group="Domes">
+      <device label="MQTT Universal ROR" manufacturer="RORO-MQTT">
+         <driver name="MQTT Universal ROR">indi-mqtt-universalror</driver>
+         <version>@CDRIVER_VERSION_MAJOR@.@CDRIVER_VERSION_MINOR@</version>
+      </device>
+   </devGroup>
+</driversList>

--- a/mqtt_universalror.xml
+++ b/mqtt_universalror.xml
@@ -1,8 +1,0 @@
-<indi>
-  <devGroup group="Domes">
-    <device label="MQTT Universal ROR" manufacturer="RORO-MQTT">
-      <driver name="MQTT Universal ROR">indi-mqtt-universalror</driver>
-      <version>1.0</version>
-    </device>
-  </devGroup>
-</indi>


### PR DESCRIPTION
## Summary
- Advertise MQTT Universal ROR driver to KStars with `indi-mqtt-universalror.xml.cmake`
- Generate and install XML via CMake and adjust install script to use new file

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b1accd44e8832e9fcad0ef69c3f89f